### PR TITLE
Handle boto3 errors

### DIFF
--- a/src/encrypt.py
+++ b/src/encrypt.py
@@ -1,16 +1,17 @@
 import base64
-import boto3
 import logging
 import os
 import uuid
+import boto3
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def handler(event, context):
-    
+
     logger.info('Incoming event!')
-    
+
     try:
 
         secret = get_secret(event)
@@ -55,6 +56,7 @@ def handler(event, context):
 
         return response
 
+
 def get_secret(event):
 
     method = event['httpMethod']
@@ -69,6 +71,7 @@ def get_secret(event):
         logger.info('Secret generated!')
 
     return secret
+
 
 def encrypt(secret):
 
@@ -86,8 +89,9 @@ def encrypt(secret):
 
     return cipher
 
+
 def get_client():
-    
+
     region = os.environ['REGION']
     kms = boto3.client('kms', region_name=region)
 

--- a/src/view.py
+++ b/src/view.py
@@ -1,15 +1,16 @@
+import os
 import base64
-import boto3
 import logging
 import json
+import boto3
 from flatten_json import unflatten
-import os
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def handler(event, context):
-    
+
     logger.info('Incoming event!')
     logger.info(f'Event:\n{event}')
 
@@ -42,6 +43,7 @@ def handler(event, context):
 
         return response
 
+
 def parse_event(event):
 
     app_id = event['queryStringParameters']['appId']
@@ -58,10 +60,11 @@ def parse_event(event):
 
     return path
 
+
 def get_params(path):
 
     ssm = get_client('ssm')
-    
+
     response = ssm.get_parameters_by_path(
         Path=f'{path}',
         Recursive=True,
@@ -74,11 +77,13 @@ def get_params(path):
 
     return naked_params
 
+
 def get_client(service):
     region = os.environ['REGION']
     client = boto3.client(service, region_name=region)
 
     return client
+
 
 def parse_params(path, naked_params):
 
@@ -100,15 +105,16 @@ def parse_params(path, naked_params):
 
         new_param = {key: value}
         flat_params = {**flat_params, **new_param}
-    
+
     logger.info('Flat params parsed!')
-    
+
     unflat_params = unflatten(flat_params, '.')
     logger.info(f'Params: {unflat_params}')
 
     params = json.dumps(unflat_params)
 
     return params
+
 
 def encrypt(secret):
 

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -27,7 +27,7 @@ class test_encrypt(unittest.TestCase):
             valid_uuid = True
         except ValueError:
             valid_uuid = False
-            
+
         self.assertTrue(valid_uuid)
 
     def test_post_empty_body(self):
@@ -45,7 +45,7 @@ class test_encrypt(unittest.TestCase):
         os.environ['REGION'] = self.region
         kms = str(encrypt.get_client())
         self.assertTrue('<botocore.client.KMS object at' in kms)
-        
+
     @mock_kms
     def test_encrypt_value(self):
         os.environ['REGION'] = self.region
@@ -54,7 +54,7 @@ class test_encrypt(unittest.TestCase):
 
         cipher = encrypt.encrypt(self.secret)
         self.assertTrue(cipher.startswith('cipher:'))
-    
+
     @mock_kms
     def test_handler(self):
         os.environ['REGION'] = self.region
@@ -114,6 +114,7 @@ class test_encrypt(unittest.TestCase):
 
         content_type = response['headers']['Content-Type']
         self.assertEqual(content_type, 'text/plain')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import uuid
 import json
 from flatten_json import flatten
 
@@ -35,8 +34,8 @@ class test_encrypt(unittest.TestCase):
 
         self.data = {**self.metadata, **self.params}
         self.body = json.dumps(self.data)
-        self.event = {'headers': {'x-test-header': 'test'}, 'queryStringParameters': {'appId': self.app_id,'stage': self.stage},'body': self.body}
-        self.event_path_override = {'headers': {'x-path-override': self.path_override},'queryStringParameters': {'appId': self.app_id,'stage': self.stage},'body': self.body}
+        self.event = {'headers': {'x-test-header': 'test'}, 'queryStringParameters': {'appId': self.app_id, 'stage': self.stage}, 'body': self.body}
+        self.event_path_override = {'headers': {'x-path-override': self.path_override}, 'queryStringParameters': {'appId': self.app_id, 'stage': self.stage}, 'body': self.body}
 
     def test_parse_event(self):
         os.environ['METADATA_AS_PARAM'] = self.metadata_as_param
@@ -64,20 +63,20 @@ class test_encrypt(unittest.TestCase):
     def __moto_ssm_setup(self):
         ssm = update.get_client('ssm')
 
-        for key,value in self.existing_param.items():
+        for key, value in self.existing_param.items():
             ssm.put_parameter(
                 Name=f'/{self.app_id}/{self.stage}/{key}',
                 Value=value,
                 Type=self.existing_param_type,
                 Overwrite=True
             )
-    
+
     @mock_kms
     def __moto_kms_setup(self):
         kms = update.get_client('kms')
         key = kms.create_key()
         kms.create_alias(AliasName=self.alias, TargetKeyId=key['KeyMetadata']['KeyId'])
-    
+
     @mock_ssm
     def test_compare_param(self):
         os.environ['REGION'] = self.region
@@ -123,6 +122,7 @@ class test_encrypt(unittest.TestCase):
         response = update.tag_param(self.path, 'foo', self.tags, ssm)
 
         self.assertTrue(response['ResponseMetadata']['HTTPStatusCode'], '200')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Problem # 1

When the JSON object has one of the items with wrong encrypted data, a HTTP client receives from AWS Lambda just a common error message like:
```
Response Code: HTTP/1.1 500 Internal Server Error
```

While AWS Lambda logs has more useful information:
```
** Key: test.path, Value: cipher:AB…CD
** KMS Key: alias/psm-key
Unexpected ClientError: An error occurred (AccessDeniedException) when calling the Decrypt operation: The ciphertext refers to a customer master key that does not exist, does not exist in this region, or you are not allowed to access.
** Secret decrypted!
END RequestId: xxx-yyy
```

### Problem # 2

In case of error in decryption, there is a message "Secret decrypted!" in logs.

### Solution

Currently, this code is just a proof of concept.