### PR TITLE
update.py: print 'Secret decrypted!' only when no exception

### DIFF
--- a/src/update.py
+++ b/src/update.py
@@ -193,8 +193,8 @@ def decrypt(value):
         kms_response = kms.decrypt(CiphertextBlob=bytes_value)
     except ClientError as e:
         logger.error(f'Unexpected ClientError: {e}')
-
-    logger.info('** Secret decrypted!')
+    else:
+        logger.info('** Secret decrypted!')
 
     bytes_decrypted_value = kms_response['Plaintext']
     value = bytes_decrypted_value.decode('utf-8')


### PR DESCRIPTION
With the old code, I see in logs:

```
[ERROR]	2022-02-16T13:52:32.920Z	xxx-7efa-4f48-a12b-yyy	Unexpected ClientError: An error occurred (AccessDeniedException) when calling the Decrypt operation: The ciphertext refers to a customer master key that does not exist, does not exist in this region, or you are not allowed to access.
[INFO]	2022-02-16T13:52:32.920Z	xxx-7efa-4f48-a12b-yyy	** Secret decrypted!
```

This fix removes "Secret decrypted!" message from logs, when exception was raised.